### PR TITLE
Ignore accented letters in search

### DIFF
--- a/app/src/main/java/com/geecee/escapelauncher/ui/views/AppsList.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ui/views/AppsList.kt
@@ -49,6 +49,7 @@ import com.geecee.escapelauncher.utils.doesWorkProfileExist
 import com.geecee.escapelauncher.utils.getAppsAlignment
 import com.geecee.escapelauncher.utils.getBooleanSetting
 import com.geecee.escapelauncher.utils.unlockPrivateSpace
+import java.text.Normalizer
 import com.geecee.escapelauncher.MainAppViewModel as MainAppModel
 import com.geecee.escapelauncher.utils.isPrivateSpaceUnlocked as isPrivateSpace
 


### PR DESCRIPTION
I ran into a problem when searching apps with accents in the name, this pull request makes it so accents in letters are ignored when searching

Let me know if you have any comments. 

Old behavior:
<img width="1080" height="2400" alt="Screenshot_20260111-151351" src="https://github.com/user-attachments/assets/84f05121-aad1-4190-b09e-0466a78a9335" />

New behavior:
<img width="1080" height="2400" alt="Screenshot_20260111-150755" src="https://github.com/user-attachments/assets/20984a90-df2b-4dca-901b-056003cc46da" />
