### PR TITLE
Implemented Samsung secure folder functionality.

### DIFF
--- a/app/src/main/java/com/geecee/escapelauncher/ui/views/AppsList.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ui/views/AppsList.kt
@@ -1,6 +1,7 @@
 package com.geecee.escapelauncher.ui.views
 
 import android.os.Build
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -44,10 +45,12 @@ import com.geecee.escapelauncher.utils.AppUtils
 import com.geecee.escapelauncher.utils.AppUtils.doHapticFeedBack
 import com.geecee.escapelauncher.utils.AppUtils.resetHome
 import com.geecee.escapelauncher.utils.PrivateSpaceSettings
+import com.geecee.escapelauncher.utils.canUseSecureFolder
 import com.geecee.escapelauncher.utils.doesPrivateSpaceExist
 import com.geecee.escapelauncher.utils.doesWorkProfileExist
 import com.geecee.escapelauncher.utils.getAppsAlignment
 import com.geecee.escapelauncher.utils.getBooleanSetting
+import com.geecee.escapelauncher.utils.launchSecureFolder
 import com.geecee.escapelauncher.utils.unlockPrivateSpace
 import com.geecee.escapelauncher.MainAppViewModel as MainAppModel
 import com.geecee.escapelauncher.utils.isPrivateSpaceUnlocked as isPrivateSpace
@@ -232,8 +235,21 @@ fun AppsList(
 
             }
 
-            //Private Space
-            if (AppUtils.isDefaultLauncher(mainAppModel.getContext()) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && doesPrivateSpaceExist(
+            //Secure Folder
+            if (canUseSecureFolder(mainAppModel.getContext())) {
+
+                item {
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    Button({
+                        launchSecureFolder(mainAppModel.getContext())
+                    }) {
+                        Text(stringResource(R.string.launch_secure_folder))
+                    }
+                }
+
+            } //Private Space
+            else if (AppUtils.isDefaultLauncher(mainAppModel.getContext()) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && doesPrivateSpaceExist(
                     mainAppModel.getContext()
                 )
             ) {

--- a/app/src/main/java/com/geecee/escapelauncher/utils/SamsungSecureFolderUtils.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/utils/SamsungSecureFolderUtils.kt
@@ -1,0 +1,80 @@
+package com.geecee.escapelauncher.utils
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.LauncherApps
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.UserHandle
+import android.os.UserManager
+import android.provider.Settings
+import android.widget.Toast
+import androidx.annotation.RequiresApi
+import com.geecee.escapelauncher.R
+
+/*
+ * Check if the device has secure folder installed just in the main user profile
+ * Secure folder was introduced in Android Pie
+ */
+@RequiresApi(Build.VERSION_CODES.P)
+fun canUseSecureFolder(context: Context): Boolean {
+    return try {
+        context.packageManager.getPackageInfo(
+            "com.samsung.knox.securefolder",
+            0
+        )
+        true
+    } catch (_: PackageManager.NameNotFoundException) {
+        false
+    }
+}
+
+/*
+ * Check if the Secure folder user profile is already created
+ */
+fun getSecureFolderProfile(context: Context): UserHandle? {
+    val launcherApps = context.getSystemService(LauncherApps::class.java)
+    val userManager = context.getSystemService(UserManager::class.java) ?: return null
+    val profiles = userManager.userProfiles
+
+    return profiles.find { profile ->
+        launcherApps.getActivityList(null, profile)
+            .any { it.componentName.packageName == "com.samsung.knox.securefolder" }
+    }
+}
+
+/*
+ * Launch the secure folder UI as an alternative.
+ * Samsung restricts listing apps from the secure folder.
+ */
+fun launchSecureFolder(context: Context) {
+
+    val secureFolderProfile = getSecureFolderProfile(context)
+    val launcherApps = context.getSystemService(LauncherApps::class.java)
+
+    if (secureFolderProfile != null && launcherApps != null) {
+        // Find the actual launcher activity from the profile
+        val activityInfo = launcherApps.getActivityList(null, secureFolderProfile)
+            .firstOrNull { it.componentName.packageName == "com.samsung.knox.securefolder" }
+
+        if (activityInfo != null) {
+            try {
+                launcherApps.startMainActivity(
+                    activityInfo.componentName,
+                    secureFolderProfile,
+                    null,
+                    null
+                )
+                return
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    // If the user has disabled Secure Folder, redirect to Settings and show a toast
+    Intent(Settings.ACTION_SECURITY_SETTINGS).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }.also { context.startActivity(it) }
+
+    Toast.makeText(context, R.string.enable_secure_folder_on_settings, Toast.LENGTH_LONG).show()
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -116,4 +116,6 @@
     <string name="rem_from_fav">Quitar de Favoritos</string>
     <string name="add_open_challenge">Añadir Cuenta Atrás para Apertura</string>
     <string name="app_info">Información de App</string>
+    <string name="launch_secure_folder">Carpeta Segura</string>
+    <string name="enable_secure_folder_on_settings">Activa la Carpeta Segura en los ajustes</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,4 +129,6 @@
     <string name="system">System</string>
     <string name="accessibility_service_description">Allows the app to turn off the screen.</string>
     <string name="back">Back</string>
+    <string name="launch_secure_folder">Secure Folder</string>
+    <string name="enable_secure_folder_on_settings">Enable the Secure Folder in settings</string>
 </resources>


### PR DESCRIPTION
# Implemented Samsung Secure Folder functionality.

## Description
Apps from secure folder cannot be listed. Doing some research I've found other launchers list the secure folder profile, so the secure folder can be launched from that with an intent.

(Only in Samsung devices with OneUI)
A button was added, now the launcher checks first if the device has installed the Samsung Folder app in the main user before the previous Private Profile logic. If so, it ads a button to open the folder from it.

If the folder is not enabled or it wasn't created, it opens the system settings in the security page, with a notification toast, explaining shortly to enable it from there.

If the folder is already enabled, it launches it's custom UI.

This is necessary to Samsung devices, as Private Profile is not implemented, and the logic is different. As the time of writting this PR, the list of private profile apps is empty on the Samsung devices.

## Type of Change
Please check the relevant options:

- [x] Bug fix
- [x] New feature
- [ ] Other (please describe):

## Additional Notes
Accessing Secure Folder UI cannot be recorded. Only pressing the button when the secure folder is disabled could be 
https://github.com/user-attachments/assets/2452c2bd-8c4d-43a9-a50a-89c68abdb74b
