### PR TITLE
Refactor: Modernize default launcher check

### DIFF
--- a/app/src/main/java/com/geecee/escapelauncher/utils/SettingsUtils.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/utils/SettingsUtils.kt
@@ -5,6 +5,7 @@ import android.app.ActivityOptions
 import android.app.role.RoleManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.provider.Settings
 import androidx.compose.foundation.layout.Arrangement
@@ -58,8 +59,17 @@ fun getDefaultLauncherPackage(context: Context): String {
  * Returns if the default launcher is escape launcher
  */
 fun isDefaultLauncher(context: Context): Boolean {
-    val launcherPackageName = getDefaultLauncherPackage(context)
-    return "com.geecee.escapelauncher" == launcherPackageName || "com.geecee.escapelauncher.dev" == launcherPackageName
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val roleManager = context.getSystemService(RoleManager::class.java)
+        return roleManager.isRoleHeld(RoleManager.ROLE_HOME)
+    } else {
+        val intent = Intent(Intent.ACTION_MAIN).apply {
+            addCategory(Intent.CATEGORY_HOME)
+        }
+        val resolveInfo = context.packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        val defaultLauncherPackage = resolveInfo?.activityInfo?.packageName
+        return context.packageName == defaultLauncherPackage
+    }
 }
 
 private const val REQUEST_ROLE_HOME_CODE = 678


### PR DESCRIPTION
Use RoleManager for Android Q and above to determine if the app is the default launcher. This simplifies the logic and uses the recommended API for newer Android versions. For older versions, the existing method of resolving the home intent is retained.

# Refactor: Use RoleManager for Default Launcher check on Android Q+

## Description
This PR updates the mechanism used to detect if the application is currently set as the system's default launcher. 

**What was changed:**
* Implemented a check using `RoleManager` for devices running Android 10 (API level 29) and higher.
* Maintained the legacy `PackageManager` and `Intent.CATEGORY_HOME` resolution logic for devices on older Android versions.

**Why this change is necessary:**
Starting with Android Q, Google introduced the `RoleManager` API to provide a more robust and streamlined way to manage system roles. Using this recommended API simplifies the codebase and ensures compatibility with modern Android permission and role standards, while the fallback ensures zero regression for users on older devices.

Fixes (issue number if applicable): #

## Type of Change
Please check the relevant options:

- [ ] Bug fix
- [x] New feature
- [x] Other (please describe): Refactoring/API Optimization

## Additional Notes
The `RoleManager` API specifically uses `isRoleHeld(RoleManager.ROLE_HOME)` which is more efficient than manually querying the package manager to resolve the home intent.