### PR TITLE
Disabled going back gesture on the home screen

### DIFF
--- a/app/src/main/java/com/geecee/escapelauncher/ViewModels.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ViewModels.kt
@@ -5,6 +5,8 @@ import android.content.ComponentName
 import android.content.Context
 import android.util.Log
 import android.view.Window
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.pager.PagerState
@@ -145,6 +147,25 @@ class HomeScreenModel(application: Application, private val mainAppViewModel: Ma
             pagerState.scrollToPage(0)
         } else {
             pagerState.scrollToPage(1)
+        }
+    }
+
+    suspend fun animatedGoToMainPage() {
+        if (getBooleanSetting(
+                context = mainAppViewModel.getContext(),
+                setting = mainAppViewModel.getContext().resources.getString(R.string.hideScreenTimePage),
+                defaultValue = false
+            )
+        ) {
+            pagerState.animateScrollToPage(
+                0,
+                animationSpec = tween(durationMillis = 500, easing = FastOutSlowInEasing)
+            )
+        } else {
+            pagerState.animateScrollToPage(
+                1,
+                animationSpec = tween(durationMillis = 500, easing = FastOutSlowInEasing)
+            )
         }
     }
 

--- a/app/src/main/java/com/geecee/escapelauncher/ui/views/HomeScreenPageManager.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ui/views/HomeScreenPageManager.kt
@@ -16,10 +16,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -66,13 +63,13 @@ fun HomeScreenPageManager(
         )
     ) 1 else 2
 
-    val homeScreenPage = appsListPage - 1
-
-    // Track with an observable the state of going back gesture
-    var goBackEnabled by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
 
     // Control if the user can go back or not depending the page
-    BackHandler(enabled = goBackEnabled) {
+    BackHandler(enabled = true) {
+        coroutineScope.launch {
+            homeScreenModel.animatedGoToMainPage()
+        }
     }
 
     // Add effect to hide keyboard on page change or open search if needed
@@ -93,9 +90,6 @@ fun HomeScreenPageManager(
                 homeScreenModel.searchExpanded.value = true
             }
         }
-
-        // Check if it's the homepage, if so, the back button gets disabled
-        goBackEnabled = homeScreenModel.pagerState.currentPage == homeScreenPage
     }
 
     // Home Screen Pages


### PR DESCRIPTION


# Disabled going back gesture on the home screen

## Description
When the user is in the main home page and presses back or makes the back gesture, if the launcher is the default one it relaunches the home page, if it isn't default, it closes the app. None of these 2 behaviors are correct, as the launcher should do nothing when pressing back in home screen.

I've created an observable boolean inside the HomeScreenPageManager composable that tracks with code if the user can go back or not, depending on the page. Also added an empty backhandler, so it overrides going back when it's disabled.

Fixes #67 

## Type of Change
Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Other (please describe):

## Additional Notes
I've seen a limitation non system launcher have is that they still show the back gesture button, but it at least won't go back exiting the launcher or relaunching the home screen.
