### PR TITLE
fix FOSS build WeatherImpl

### DIFF
--- a/app/src/foss/java/com/geecee/escapelauncher/utils/WeatherImpl.kt
+++ b/app/src/foss/java/com/geecee/escapelauncher/utils/WeatherImpl.kt
@@ -3,7 +3,7 @@ package com.geecee.escapelauncher.utils
 import android.content.Context
 
 class WeatherImpl : WeatherProxy {
-    override fun getWeather(context: Context, callback: (String) -> Unit) {
+    override fun getWeather(context: Context, useFarenheit: Boolean, callback: (String) -> Unit) {
         callback("Weather is not available on the FOSS version of the app")
     }
 }


### PR DESCRIPTION
FOSS version couldn't be build anymore, cause proxy signature was changed in 2ad919c558cde86631e48e09a2281fd87c428a37. This PR fixes the FOSS WeatherImpl method signature.

## Type of Change
Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Other (please describe):

