### PR TITLE
Correctly clear text from search bar in rare conditon (possible fix for #55)

### DIFF
--- a/app/src/main/java/com/geecee/escapelauncher/ui/views/HomeScreenPageManager.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ui/views/HomeScreenPageManager.kt
@@ -75,10 +75,11 @@ fun HomeScreenPageManager(
     // Add effect to hide keyboard on page change or open search if needed
     LaunchedEffect(homeScreenModel.pagerState.currentPage) {
         if (homeScreenModel.pagerState.currentPage != appsListPage) {
-            focusManager.clearFocus()
-            keyboardController?.hide()
             homeScreenModel.searchText.value = ""
             homeScreenModel.searchExpanded.value = false
+
+            focusManager.clearFocus()
+            keyboardController?.hide()
         } else {
             // If we are on the apps list page and auto search is enabled, open it
             if (getBooleanSetting(


### PR DESCRIPTION
Correctly clear text from search bar in rare conditon (possible fix for #55)

## Description
I think this might be a race condition, specifically because `clearFocus ` can take a long time and Android might be stopping `LaunchedEffect` before it has time to finish.

Fixes (issue number if applicable)
#55 

## Type of Change
Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Other (please describe):

## Additional Notes
I am not sure but looking through the code and searching around, this seems to be the likely culprit.

I was never able to repeat this on my end, so I can't say if this definitely fixes it.
