### PR TITLE
Add a cache to FavouriteManager

### DIFF
--- a/app/src/main/java/com/geecee/escapelauncher/utils/managers/FavouritesManager.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/utils/managers/FavouritesManager.kt
@@ -12,6 +12,7 @@ class FavoriteAppsManager(context: Context) {
 
     private val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     private val gson = Gson()
+    private var favoriteAppsCache: MutableList<String>? = null
 
     companion object {
         private const val PREFS_NAME = Migration.UNIFIED_PREFS_NAME
@@ -19,6 +20,8 @@ class FavoriteAppsManager(context: Context) {
     }
 
     private fun saveFavoriteApps(favoriteApps: List<String>) {
+        favoriteAppsCache = favoriteApps.toMutableList()
+
         val json = gson.toJson(favoriteApps)
         sharedPreferences.edit {
             putString(FAVORITE_APPS_KEY, json)
@@ -26,13 +29,19 @@ class FavoriteAppsManager(context: Context) {
     }
 
     fun getFavoriteApps(): List<String> {
+        // Check if the Favourite List is in memory.
+        favoriteAppsCache?.let { return it.toList() }
+
         val json = sharedPreferences.getString(FAVORITE_APPS_KEY, null)
-        return if (json != null) {
+        val favList: List<String> = if (json != null) {
             val type = object : TypeToken<List<String>>() {}.type
             gson.fromJson(json, type)
         } else {
             emptyList()
         }
+
+        favoriteAppsCache = favList.toMutableList()
+        return favList
     }
 
     fun addFavoriteApp(packageName: String) {


### PR DESCRIPTION
Add a cache to FavouriteManager

## Description
This performs a write to cache first which is order of magnitude faster than writing to disk.
This fixes the issue where dragging Favourite Apps quickly can cause them to not be present in the position where they were dragged to.

Fixes (issue number if applicable)
#60 

## Type of Change
Please check the relevant options:

- [x] Bug fix
- [ ] New feature
- [ ] Other (please describe):

## Additional Notes
Sorry if I ended up using `favourite` in comments in code anywhere. I'm not used to writing in American English.
