### PR TITLE
Allow users to choose countdown duration.

### DIFF
--- a/app/src/main/java/com/geecee/escapelauncher/ui/composables/SettingsComposables.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ui/composables/SettingsComposables.kt
@@ -401,6 +401,7 @@ fun SettingsButton(
     isBottomOfGroup: Boolean = false,
     fontFamily: FontFamily? = MaterialTheme.typography.bodyMedium.fontFamily,
     isDisabled: Boolean = false,
+    isSelected: Boolean = false,
     useAutoResize: Boolean = true
 ) {
     // Define the base corner size
@@ -425,7 +426,11 @@ fun SettingsButton(
     )
 
     val animatedContainerColor by animateColorAsState(
-        targetValue = if (!isDisabled) CardContainerColor else CardContainerColorDisabled,
+        targetValue = when {
+            isDisabled -> CardContainerColorDisabled
+            isSelected -> CardContainerColor.copy(alpha = 0.5f)
+            else -> CardContainerColor
+        },
         animationSpec = tween(durationMillis = 300),
         label = "containerColor"
     )

--- a/app/src/main/java/com/geecee/escapelauncher/ui/views/HomeScreenPageManager.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ui/views/HomeScreenPageManager.kt
@@ -75,10 +75,11 @@ fun HomeScreenPageManager(
     // Add effect to hide keyboard on page change or open search if needed
     LaunchedEffect(homeScreenModel.pagerState.currentPage) {
         if (homeScreenModel.pagerState.currentPage != appsListPage) {
-            focusManager.clearFocus()
-            keyboardController?.hide()
             homeScreenModel.searchText.value = ""
             homeScreenModel.searchExpanded.value = false
+
+            focusManager.clearFocus()
+            keyboardController?.hide()
         } else {
             // If we are on the apps list page and auto search is enabled, open it
             if (getBooleanSetting(

--- a/app/src/main/java/com/geecee/escapelauncher/ui/views/HomeScreenPageManager.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ui/views/HomeScreenPageManager.kt
@@ -75,11 +75,10 @@ fun HomeScreenPageManager(
     // Add effect to hide keyboard on page change or open search if needed
     LaunchedEffect(homeScreenModel.pagerState.currentPage) {
         if (homeScreenModel.pagerState.currentPage != appsListPage) {
-            homeScreenModel.searchText.value = ""
-            homeScreenModel.searchExpanded.value = false
-
             focusManager.clearFocus()
             keyboardController?.hide()
+            homeScreenModel.searchText.value = ""
+            homeScreenModel.searchExpanded.value = false
         } else {
             // If we are on the apps list page and auto search is enabled, open it
             if (getBooleanSetting(

--- a/app/src/main/java/com/geecee/escapelauncher/ui/views/Settings.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ui/views/Settings.kt
@@ -108,6 +108,10 @@ import com.geecee.escapelauncher.utils.getWidgetWidth
 import com.geecee.escapelauncher.utils.isDefaultLauncher
 import com.geecee.escapelauncher.utils.isWidgetConfigurable
 import com.geecee.escapelauncher.utils.launchWidgetConfiguration
+import com.geecee.escapelauncher.utils.managers.CountdownMode
+import com.geecee.escapelauncher.utils.managers.getCountdownTime
+import com.geecee.escapelauncher.utils.managers.resetAndGetCountdownTime
+import com.geecee.escapelauncher.utils.managers.setCountdownTime
 import com.geecee.escapelauncher.utils.removeWidget
 import com.geecee.escapelauncher.utils.resetActivity
 import com.geecee.escapelauncher.utils.saveWidgetId
@@ -290,6 +294,14 @@ fun Settings(
                 enterTransition = { fadeIn(tween(300)) },
                 exitTransition = { fadeOut(tween(300)) }) {
                 FontLicenceDialog(mainAppModel.getContext()) {
+                    navController.popBackStack()
+                }
+            }
+            composable(
+                "newSettingsScreen",
+                enterTransition = { fadeIn(tween(300)) },
+                exitTransition = { fadeOut(tween(300)) }) {
+                AppCountdownTime(mainAppModel.getContext()) {
                     navController.popBackStack()
                 }
             }
@@ -705,6 +717,18 @@ fun MainSettingsPage(
                 false,
                 isBottomOfGroup = true,
                 onClick = { navController.navigate("openChallenges") })
+        }
+
+        // New Settings
+        item { SettingsSubheading(stringResource(id = R.string.new_settings)) }
+
+        item {
+            SettingsNavigationItem(
+                label = stringResource(id = R.string.set_app_countdown_time),
+                false,
+                isTopOfGroup = true,
+                isBottomOfGroup = true,
+                onClick = { navController.navigate("newSettingsScreen") })
         }
 
         //Other
@@ -1589,5 +1613,53 @@ fun FontLicenceDialog(context: Context, onOKClick: () -> Unit) {
         SettingsSpacer()
         SettingsSpacer()
         SettingsSpacer()
+    }
+}
+
+@Composable
+fun AppCountdownTime(context: Context, goBack: () -> Unit) {
+    var countdownTime by remember { mutableFloatStateOf(getCountdownTime(context)) }
+
+    LazyColumn(
+        verticalArrangement = Arrangement.Top,
+        horizontalAlignment = Alignment.Start,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        item { SettingsHeader(goBack, stringResource(R.string.new_settings)) }
+
+        itemsIndexed(CountdownMode.entries) {index, mode ->
+            SettingsButton(
+                label = stringResource(mode.labelRes),
+                isSelected = countdownTime == mode.value,
+                isTopOfGroup = index == 0,
+                isBottomOfGroup = index == CountdownMode.entries.size - 1,
+                onClick = {
+                    countdownTime = mode.value
+                    setCountdownTime(context, mode.value)
+                }
+            )
+        }
+
+        item { SettingsSpacer() }
+
+        item {
+            SettingsSlider(
+                label = stringResource(R.string.set_app_countdown_time_slider),
+                value = countdownTime,
+                onValueChange = {
+                    countdownTime = it
+                    setCountdownTime(context, countdownTime)
+                },
+                valueRange = 1f..5f,
+                steps = 3,
+                onReset = {
+                    countdownTime = resetAndGetCountdownTime(context)
+                },
+                isTopOfGroup = true,
+                isBottomOfGroup = true
+            )
+        }
+
+        item { SettingsSpacer() }
     }
 }

--- a/app/src/main/java/com/geecee/escapelauncher/ui/views/Settings.kt
+++ b/app/src/main/java/com/geecee/escapelauncher/ui/views/Settings.kt
@@ -720,7 +720,7 @@ fun MainSettingsPage(
         }
 
         // New Settings
-        item { SettingsSubheading(stringResource(id = R.string.new_settings)) }
+        item { SettingsSubheading(stringResource(id = R.string.custom_settings)) }
 
         item {
             SettingsNavigationItem(
@@ -1625,7 +1625,7 @@ fun AppCountdownTime(context: Context, goBack: () -> Unit) {
         horizontalAlignment = Alignment.Start,
         modifier = Modifier.fillMaxSize()
     ) {
-        item { SettingsHeader(goBack, stringResource(R.string.new_settings)) }
+        item { SettingsHeader(goBack, stringResource(R.string.countdown_time_title)) }
 
         itemsIndexed(CountdownMode.entries) {index, mode ->
             SettingsButton(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,6 +92,12 @@
     <string name="accessibility_not_granted_msg">Please grant accessibility permission in settings</string>
     <string name="launcher_must_be_default_to_pause_or_unpause_work_apps">Launcher must be set as deafault to pause or unpause work apps</string>
     <string name="use_farenhight">Use fahrenheit</string>
+    <string name="set_app_countdown_time">Set App Countdown Time</string>
+    <string name="set_app_countdown_time_long">Long Time</string>
+    <string name="set_app_countdown_time_normal">Normal Time</string>
+    <string name="set_app_countdown_time_short">Short Time</string>
+    <string name="set_app_countdown_time_slider">Change Time</string>
+    <string name="new_settings">New Settings</string>
 
     <!-- First time strings -->
     <string name="continue_str">Continue</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,8 @@
     <string name="set_app_countdown_time_normal">Normal Time</string>
     <string name="set_app_countdown_time_short">Short Time</string>
     <string name="set_app_countdown_time_slider">Change Time</string>
-    <string name="new_settings">New Settings</string>
+    <string name="custom_settings">Custom Settings</string>
+    <string name="countdown_time_title">Countdown Time</string>
 
     <!-- First time strings -->
     <string name="continue_str">Continue</string>


### PR DESCRIPTION
Allow users to choose countdown duration.

## Description
This allows user to change the default countdown timer of 3 seconds.
The lowest possible duration is 1 second and the highest 5 seconds per number.

Fixes (issue number if applicable)
#108 

## Type of Change
Please check the relevant options:

- [ ] Bug fix
- [x] New feature
- [ ] Other (please describe):

## Additional Notes
* The current name and strings for this setting are all placeholder.

* Added isSelected property to `SettingsButton` which turns down the alpha by 50% for selected button.
* Moved default value of countdown time to a constant.

Screenshot:
<img width="672" height="1490" alt="Screenshot 2026-02-07 133528" src="https://github.com/user-attachments/assets/a00e4510-d8e1-4e0a-a209-afd4293c8838" />
